### PR TITLE
Add additional scihub addresses to avoid blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,14 @@
        "label": "sci-hub.cc"},
       {"value": "sci-hub.io",
        "label": "sci-hub.io"},
+	    {"value": "sci-hub.ac",
+       "label": "sci-hub.ac"},
+	    {"value": "80.82.78.170",
+       "label": "80.82.78.170"},
       {"value": "scihub22266oqcxt.onion",
        "label": "scihub2226oqcxt.onion (only for Tor users)"}
+      {"value": "scihub22266oqcxt.onion.link",
+       "label": "scihub22266oqcxt.onion.link (Hosted on Tor, but sent over clearnet)"}
     ]
   }]
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
        "label": "sci-hub.cc"},
       {"value": "sci-hub.io",
        "label": "sci-hub.io"},
-	    {"value": "sci-hub.ac",
+      {"value": "sci-hub.ac",
        "label": "sci-hub.ac"},
-	    {"value": "80.82.78.170",
+      {"value": "80.82.78.170",
        "label": "80.82.78.170"},
       {"value": "scihub22266oqcxt.onion",
        "label": "scihub2226oqcxt.onion (only for Tor users)"}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "scihubify",
   "name": "scihubify",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Open Links on Sci-Hub, search for selected text on Sci-Hub",
   "main": "index.js",
   "author": "Rev. Wicks Cherrycoke",
@@ -17,7 +17,7 @@
     "name": "scihubDomain",
     "title": "Sci-Hub Domain",
     "type": "menulist",
-    "value": "sci-hub.cc",
+    "value": "sci-hub.ac",
     "options": [
       {"value": "sci-hub.bz",
        "label": "sci-hub.bz"},
@@ -31,8 +31,6 @@
        "label": "80.82.78.170"},
       {"value": "scihub22266oqcxt.onion",
        "label": "scihub2226oqcxt.onion (only for Tor users)"}
-      {"value": "scihub22266oqcxt.onion.link",
-       "label": "scihub22266oqcxt.onion.link (Hosted on Tor, but sent over clearnet)"}
     ]
   }]
 }


### PR DESCRIPTION
Just added some extra links as a few had been bocked in sunny old England, Best Jon
sci-hub.ac, ip:80.82.78.170, and a Tor portal(I don't trust it but I've put a warning, what can you do?: scihub22266oqcxt.onion.link
