### PR TITLE
Adding sci-hub.tw

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
        "label": "sci-hub.cc"},
       {"value": "sci-hub.io",
        "label": "sci-hub.io"},
+      {"value": "sci-hub.tw",
+       "label": "sci-hub.tw"},
       {"value": "scihub22266oqcxt.onion",
        "label": "scihub2226oqcxt.onion (only for Tor users)"}
     ]


### PR DESCRIPTION
Hi @revcherrycoke,
In this moment the domain which works is sci-hub.tw, .bz and .cc don't works now and I don't know about the onion direction.

Regards,
Iván